### PR TITLE
Fix snake_case to camelCase for table_prefix variables

### DIFF
--- a/src/MemberPressCoursesCopilot/Services/DatabaseBackupService.php
+++ b/src/MemberPressCoursesCopilot/Services/DatabaseBackupService.php
@@ -26,7 +26,7 @@ class DatabaseBackupService extends BaseService
      *
      * @var string
      */
-    private string $table_prefix;
+    private string $tablePrefix;
 
     /**
      * Backup directory path
@@ -50,7 +50,7 @@ class DatabaseBackupService extends BaseService
         parent::__construct();
         global $wpdb;
         $this->wpdb         = $wpdb;
-        $this->table_prefix = $wpdb->prefix . 'mpcc_';
+        $this->tablePrefix = $wpdb->prefix . 'mpcc_';
 
         // Set up backup directory
         $upload_dir       = wp_upload_dir();
@@ -384,7 +384,7 @@ class DatabaseBackupService extends BaseService
         $tables = [];
 
         // Get all tables with our prefix
-        $all_tables = $this->wpdb->get_col("SHOW TABLES LIKE '{$this->table_prefix}%'");
+        $all_tables = $this->wpdb->get_col("SHOW TABLES LIKE '{$this->tablePrefix}%'");
 
         foreach ($all_tables as $table) {
             $tables[] = $table;

--- a/src/MemberPressCoursesCopilot/Services/DatabaseService.php
+++ b/src/MemberPressCoursesCopilot/Services/DatabaseService.php
@@ -33,7 +33,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      *
      * @var string
      */
-    private string $table_prefix;
+    private string $tablePrefix;
 
     /**
      * Database constructor
@@ -43,7 +43,7 @@ class DatabaseService extends BaseService implements IDatabaseService
         parent::__construct();
         global $wpdb;
         $this->wpdb         = $wpdb;
-        $this->table_prefix = $wpdb->prefix . 'mpcc_';
+        $this->tablePrefix = $wpdb->prefix . 'mpcc_';
     }
 
     /**
@@ -91,7 +91,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     private function createConversationsTable(): void
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         $sql = "CREATE TABLE IF NOT EXISTS {$tableName} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -130,7 +130,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     private function createTemplatesTable(): void
     {
-        $tableName = $this->table_prefix . 'templates';
+        $tableName = $this->tablePrefix . 'templates';
 
         $sql = "CREATE TABLE IF NOT EXISTS {$tableName} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -170,7 +170,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     private function createCoursePatternsTable(): void
     {
-        $tableName = $this->table_prefix . 'course_patterns';
+        $tableName = $this->tablePrefix . 'course_patterns';
 
         $sql = "CREATE TABLE IF NOT EXISTS {$tableName} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -213,7 +213,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     private function createUsageAnalyticsTable(): void
     {
-        $tableName = $this->table_prefix . 'usage_analytics';
+        $tableName = $this->tablePrefix . 'usage_analytics';
 
         $sql = "CREATE TABLE IF NOT EXISTS {$tableName} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -243,7 +243,7 @@ class DatabaseService extends BaseService implements IDatabaseService
             KEY idx_created_at (created_at),
             KEY idx_cost_amount (cost_amount),
             KEY idx_response_time (response_time_ms),
-            FOREIGN KEY fk_conversation (conversation_id) REFERENCES {$this->table_prefix}conversations(id) ON DELETE SET NULL
+            FOREIGN KEY fk_conversation (conversation_id) REFERENCES {$this->tablePrefix}conversations(id) ON DELETE SET NULL
         ) {$this->getCharsetCollation()};";
 
         $this->executeQuery($sql, 'Failed to create usage analytics table');
@@ -257,7 +257,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     private function createQualityMetricsTable(): void
     {
-        $tableName = $this->table_prefix . 'quality_metrics';
+        $tableName = $this->tablePrefix . 'quality_metrics';
 
         $sql = "CREATE TABLE IF NOT EXISTS {$tableName} (
             id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -289,8 +289,8 @@ class DatabaseService extends BaseService implements IDatabaseService
             KEY idx_human_reviewed (human_reviewed),
             KEY idx_human_reviewer_id (human_reviewer_id),
             KEY idx_created_at (created_at),
-            FOREIGN KEY fk_quality_conversation (conversation_id) REFERENCES {$this->table_prefix}conversations(id) ON DELETE SET NULL,
-            FOREIGN KEY fk_quality_pattern (pattern_id) REFERENCES {$this->table_prefix}course_patterns(id) ON DELETE SET NULL
+            FOREIGN KEY fk_quality_conversation (conversation_id) REFERENCES {$this->tablePrefix}conversations(id) ON DELETE SET NULL,
+            FOREIGN KEY fk_quality_pattern (pattern_id) REFERENCES {$this->tablePrefix}course_patterns(id) ON DELETE SET NULL
         ) {$this->getCharsetCollation()};";
 
         $this->executeQuery($sql, 'Failed to create quality metrics table');
@@ -328,7 +328,7 @@ class DatabaseService extends BaseService implements IDatabaseService
             ];
 
             foreach ($tables as $table) {
-                $tableName = $this->table_prefix . $table;
+                $tableName = $this->tablePrefix . $table;
                 $sql       = "DROP TABLE IF EXISTS {$tableName}";
                 $this->wpdb->query($sql);
             }
@@ -398,14 +398,14 @@ class DatabaseService extends BaseService implements IDatabaseService
 
         // Add index for created_by in templates table
         $this->addIndexIfNotExists(
-            $this->table_prefix . 'templates',
+            $this->tablePrefix . 'templates',
             'idx_created_by',
             'created_by'
         );
 
         // Add index for human_reviewer_id in quality_metrics table
         $this->addIndexIfNotExists(
-            $this->table_prefix . 'quality_metrics',
+            $this->tablePrefix . 'quality_metrics',
             'idx_human_reviewer_id',
             'human_reviewer_id'
         );
@@ -540,7 +540,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function insertConversation(array $data): int|false
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         // Add a small random delay to ensure unique timestamps
         usleep(wp_rand(1000, 5000)); // Sleep for 1-5 milliseconds.
@@ -574,7 +574,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function updateConversation(int $conversationId, array $data): bool
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         // Only update timestamp if we're updating actual content, not just metadata or state
         $contentFields     = ['messages', 'title', 'step_data'];
@@ -612,7 +612,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getConversation(int $conversationId): ?object
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe
         $result = $this->wpdb->get_row(
@@ -635,7 +635,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getConversationsByUser(int $userId, int $limit = 20, int $offset = 0): array
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Table name is safe
         $results = $this->wpdb->get_results(
@@ -658,7 +658,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function insertTemplate(array $data): int|false
     {
-        $tableName = $this->table_prefix . 'templates';
+        $tableName = $this->tablePrefix . 'templates';
 
         $defaults = [
             'category'    => 'general',
@@ -687,7 +687,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getTemplates(string $category = '', string $type = ''): array
     {
-        $tableName = $this->table_prefix . 'templates';
+        $tableName = $this->tablePrefix . 'templates';
 
         $where_conditions = ['is_active = 1'];
         $params           = [];
@@ -723,7 +723,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function recordUsage(array $data): int|false
     {
-        $tableName = $this->table_prefix . 'usage_analytics';
+        $tableName = $this->tablePrefix . 'usage_analytics';
 
         $defaults = [
             'tokens_used' => 0,
@@ -751,7 +751,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getUsageAnalytics(string $start_date, string $end_date, ?int $userId = null): array
     {
-        $tableName = $this->table_prefix . 'usage_analytics';
+        $tableName = $this->tablePrefix . 'usage_analytics';
 
         $where_conditions = ['created_at BETWEEN %s AND %s'];
         $params           = [$start_date, $end_date];
@@ -791,7 +791,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getQualityMetricsSummary(?int $courseId = null): ?object
     {
-        $tableName = $this->table_prefix . 'quality_metrics';
+        $tableName = $this->tablePrefix . 'quality_metrics';
 
         $where_clause = $courseId ? 'WHERE course_id = %d' : '';
         $params       = $courseId ? [$courseId] : [];
@@ -858,7 +858,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getConversationBySessionId(string $sessionId): ?object
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         $result = $this->wpdb->get_row(
             $this->wpdb->prepare(
@@ -883,7 +883,7 @@ class DatabaseService extends BaseService implements IDatabaseService
             return [];
         }
 
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         // Prepare placeholders for the IN clause
         $placeholders = implode(',', array_fill(0, count($sessionIds), '%s'));
@@ -916,7 +916,7 @@ class DatabaseService extends BaseService implements IDatabaseService
             return [];
         }
 
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         // Prepare placeholders for the IN clause
         $placeholders = implode(',', array_fill(0, count($conversationIds), '%d'));
@@ -949,14 +949,14 @@ class DatabaseService extends BaseService implements IDatabaseService
 
             // Add index for created_by in templates table
             $this->addIndexIfNotExists(
-                $this->table_prefix . 'templates',
+                $this->tablePrefix . 'templates',
                 'idx_created_by',
                 'created_by'
             );
 
             // Add index for human_reviewer_id in quality_metrics table
             $this->addIndexIfNotExists(
-                $this->table_prefix . 'quality_metrics',
+                $this->tablePrefix . 'quality_metrics',
                 'idx_human_reviewer_id',
                 'human_reviewer_id'
             );
@@ -979,18 +979,18 @@ class DatabaseService extends BaseService implements IDatabaseService
         $missing = [];
 
         // Check templates table indexes
-        if (!$this->indexExists($this->table_prefix . 'templates', 'idx_created_by')) {
+        if (!$this->indexExists($this->tablePrefix . 'templates', 'idx_created_by')) {
             $missing[] = [
-                'table'      => $this->table_prefix . 'templates',
+                'table'      => $this->tablePrefix . 'templates',
                 'index_name' => 'idx_created_by',
                 'column'     => 'created_by',
             ];
         }
 
         // Check quality_metrics table indexes
-        if (!$this->indexExists($this->table_prefix . 'quality_metrics', 'idx_human_reviewer_id')) {
+        if (!$this->indexExists($this->tablePrefix . 'quality_metrics', 'idx_human_reviewer_id')) {
             $missing[] = [
-                'table'      => $this->table_prefix . 'quality_metrics',
+                'table'      => $this->tablePrefix . 'quality_metrics',
                 'index_name' => 'idx_human_reviewer_id',
                 'column'     => 'human_reviewer_id',
             ];
@@ -1042,7 +1042,7 @@ class DatabaseService extends BaseService implements IDatabaseService
         $status = [];
 
         foreach ($tables as $table) {
-            $tableName = $this->table_prefix . $table;
+            $tableName = $this->tablePrefix . $table;
             $exists    = $this->wpdb->get_var(
                 $this->wpdb->prepare(
                     'SELECT COUNT(1) FROM INFORMATION_SCHEMA.TABLES 
@@ -1148,7 +1148,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getActiveSessionCount(int $userId): int
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         $result = $this->wpdb->get_var(
             $this->wpdb->prepare(
@@ -1168,7 +1168,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getOldestActiveSession(int $userId): ?object
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         $result = $this->wpdb->get_row(
             $this->wpdb->prepare(
@@ -1188,7 +1188,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getExpiredSessions(int $expired_before_timestamp): array
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         $results = $this->wpdb->get_results(
             $this->wpdb->prepare(
@@ -1208,7 +1208,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function deleteConversation(int $conversationId): bool
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         $result = $this->wpdb->delete(
             $tableName,
@@ -1229,7 +1229,7 @@ class DatabaseService extends BaseService implements IDatabaseService
      */
     public function getActiveSessionsNeedingSave(int $minutes_since_update = 5, int $limit = 100): array
     {
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         // Calculate the timestamp for comparison
         $cutoff_time = date('Y-m-d H:i:s', time() - ($minutes_since_update * 60));
@@ -1263,7 +1263,7 @@ class DatabaseService extends BaseService implements IDatabaseService
             return 0;
         }
 
-        $tableName = $this->table_prefix . 'conversations';
+        $tableName = $this->tablePrefix . 'conversations';
 
         // Prepare placeholders for the IN clause
         $placeholders = implode(',', array_fill(0, count($conversationIds), '%d'));

--- a/src/MemberPressCoursesCopilot/Services/LessonDraftService.php
+++ b/src/MemberPressCoursesCopilot/Services/LessonDraftService.php
@@ -32,10 +32,10 @@ class LessonDraftService
     private function ensureTableExists()
     {
         global $wpdb;
-        $table_name = $this->table->getTableName();
+        $tableName = $this->table->getTableName();
 
         // Check if table exists
-        $table_exists = $wpdb->get_var("SHOW TABLES LIKE '{$table_name}'") === $table_name;
+        $table_exists = $wpdb->get_var("SHOW TABLES LIKE '{$tableName}'") === $tableName;
 
         if (!$table_exists) {
             $this->table->create();
@@ -46,34 +46,34 @@ class LessonDraftService
     /**
      * Save or update a lesson draft
      */
-    public function saveDraft($session_id, $section_id, $lesson_id, $content, $order_index = 0)
+    public function saveDraft($sessionId, $sectionId, $lessonId, $content, $orderIndex = 0)
     {
         global $wpdb;
 
-        $table_name = $this->table->getTableName();
+        $tableName = $this->table->getTableName();
 
         // Check if draft exists
         $existing = $wpdb->get_row(
             $wpdb->prepare(
-                "SELECT id FROM {$table_name} WHERE session_id = %s AND section_id = %s AND lesson_id = %s",
-                $session_id,
-                $section_id,
-                $lesson_id
+                "SELECT id FROM {$tableName} WHERE session_id = %s AND section_id = %s AND lesson_id = %s",
+                $sessionId,
+                $sectionId,
+                $lessonId
             )
         );
 
         $data = [
-            'session_id'  => $session_id,
-            'section_id'  => $section_id,
-            'lesson_id'   => $lesson_id,
+            'session_id'  => $sessionId,
+            'section_id'  => $sectionId,
+            'lesson_id'   => $lessonId,
             'content'     => $content, // Content is already sanitized in the AJAX handler
-            'order_index' => intval($order_index),
+            'order_index' => intval($orderIndex),
         ];
 
         if ($existing) {
             // Update existing draft
             $result = $wpdb->update(
-                $table_name,
+                $tableName,
                 $data,
                 ['id' => $existing->id],
                 ['%s', '%s', '%s', '%s', '%d'],
@@ -82,18 +82,18 @@ class LessonDraftService
         } else {
             // Insert new draft
             $result = $wpdb->insert(
-                $table_name,
+                $tableName,
                 $data,
                 ['%s', '%s', '%s', '%s', '%d']
             );
         }
 
         if ($result === false) {
-            error_log('MPCC: Failed to save lesson draft - Session: ' . $session_id . ', Lesson: ' . $lesson_id . ', Error: ' . $wpdb->last_error);
+            error_log('MPCC: Failed to save lesson draft - Session: ' . $sessionId . ', Lesson: ' . $lessonId . ', Error: ' . $wpdb->last_error);
             return false;
         }
 
-        error_log('MPCC: Lesson draft saved - Session: ' . $session_id . ', Lesson: ' . $lesson_id . ', Content length: ' . strlen($content));
+        error_log('MPCC: Lesson draft saved - Session: ' . $sessionId . ', Lesson: ' . $lessonId . ', Content length: ' . strlen($content));
 
         return true;
     }
@@ -101,18 +101,18 @@ class LessonDraftService
     /**
      * Get a specific lesson draft
      */
-    public function getDraft($session_id, $section_id, $lesson_id)
+    public function getDraft($sessionId, $sectionId, $lessonId)
     {
         global $wpdb;
 
-        $table_name = $this->table->getTableName();
+        $tableName = $this->table->getTableName();
 
         $draft = $wpdb->get_row(
             $wpdb->prepare(
-                "SELECT * FROM {$table_name} WHERE session_id = %s AND section_id = %s AND lesson_id = %s",
-                $session_id,
-                $section_id,
-                $lesson_id
+                "SELECT * FROM {$tableName} WHERE session_id = %s AND section_id = %s AND lesson_id = %s",
+                $sessionId,
+                $sectionId,
+                $lessonId
             )
         );
 
@@ -122,16 +122,16 @@ class LessonDraftService
     /**
      * Get all drafts for a session
      */
-    public function getSessionDrafts($session_id)
+    public function getSessionDrafts($sessionId)
     {
         global $wpdb;
 
-        $table_name = $this->table->getTableName();
+        $tableName = $this->table->getTableName();
 
         $drafts = $wpdb->get_results(
             $wpdb->prepare(
-                "SELECT * FROM {$table_name} WHERE session_id = %s ORDER BY section_id, order_index",
-                $session_id
+                "SELECT * FROM {$tableName} WHERE session_id = %s ORDER BY section_id, order_index",
+                $sessionId
             )
         );
 
@@ -141,28 +141,28 @@ class LessonDraftService
     /**
      * Delete a lesson draft
      */
-    public function deleteDraft($session_id, $section_id, $lesson_id)
+    public function deleteDraft($sessionId, $sectionId, $lessonId)
     {
         global $wpdb;
 
-        $table_name = $this->table->getTableName();
+        $tableName = $this->table->getTableName();
 
         $result = $wpdb->delete(
-            $table_name,
+            $tableName,
             [
-                'session_id' => $session_id,
-                'section_id' => $section_id,
-                'lesson_id'  => $lesson_id,
+                'session_id' => $sessionId,
+                'section_id' => $sectionId,
+                'lesson_id'  => $lessonId,
             ],
             ['%s', '%s', '%s']
         );
 
         if ($result === false) {
-            error_log('MPCC: Failed to delete lesson draft - Session: ' . $session_id . ', Lesson: ' . $lesson_id . ', Error: ' . $wpdb->last_error);
+            error_log('MPCC: Failed to delete lesson draft - Session: ' . $sessionId . ', Lesson: ' . $lessonId . ', Error: ' . $wpdb->last_error);
             return false;
         }
 
-        error_log('MPCC: Lesson draft deleted - Session: ' . $session_id . ', Lesson: ' . $lesson_id);
+        error_log('MPCC: Lesson draft deleted - Session: ' . $sessionId . ', Lesson: ' . $lessonId);
 
         return true;
     }
@@ -170,24 +170,24 @@ class LessonDraftService
     /**
      * Delete all drafts for a session
      */
-    public function deleteSessionDrafts($session_id)
+    public function deleteSessionDrafts($sessionId)
     {
         global $wpdb;
 
-        $table_name = $this->table->getTableName();
+        $tableName = $this->table->getTableName();
 
         $result = $wpdb->delete(
-            $table_name,
-            ['session_id' => $session_id],
+            $tableName,
+            ['session_id' => $sessionId],
             ['%s']
         );
 
         if ($result === false) {
-            error_log('MPCC: Failed to delete session drafts - Session: ' . $session_id . ', Error: ' . $wpdb->last_error);
+            error_log('MPCC: Failed to delete session drafts - Session: ' . $sessionId . ', Error: ' . $wpdb->last_error);
             return false;
         }
 
-        error_log('MPCC: Session drafts deleted - Session: ' . $session_id . ', Count: ' . $result);
+        error_log('MPCC: Session drafts deleted - Session: ' . $sessionId . ', Count: ' . $result);
 
         return $result;
     }
@@ -199,12 +199,12 @@ class LessonDraftService
     {
         global $wpdb;
 
-        $table_name = $this->table->getTableName();
+        $tableName = $this->table->getTableName();
         $success    = true;
 
         foreach ($lesson_orders as $lesson_id => $order) {
             $result = $wpdb->update(
-                $table_name,
+                $tableName,
                 ['order_index' => intval($order)],
                 [
                     'session_id' => $session_id,
@@ -291,7 +291,7 @@ class LessonDraftService
     {
         global $wpdb;
 
-        $table_name = $this->table->getTableName();
+        $tableName = $this->table->getTableName();
 
         // Get all drafts from the source session
         $sourceDrafts = $this->getSessionDrafts($sourceSessionId);


### PR DESCRIPTION
- Changed $table_prefix to $tablePrefix in DatabaseService.php
- Changed $table_prefix to $tablePrefix in DatabaseBackupService.php
- Changed $session_id to $sessionId in LessonDraftService.php
- Changed $section_id to $sectionId in LessonDraftService.php
- Changed $lesson_id to $lessonId in LessonDraftService.php
- Changed $order_index to $orderIndex in LessonDraftService.php
- Changed $table_name to $tableName in LessonDraftService.php

Part of PHPCS compliance fixes for issue #109

🤖 Generated with [Claude Code](https://claude.ai/code)