### PR TITLE
Update PHPCS documentation with snake_case fixes

### DIFF
--- a/docs/PHPCS_REMAINING_ISSUES.md
+++ b/docs/PHPCS_REMAINING_ISSUES.md
@@ -42,13 +42,18 @@ After implementing PHPCS with Caseproof-WP-Standard and fixing critical issues, 
     - Fixed missing @param, @return, @throws, and @since tags in 5 high-priority files
     - Applied 175 automatic fixes for PHPDoc formatting
     - Improved documentation for MpccQuizAjaxController, SimpleAjaxController, ConversationSession, DatabaseService, and SessionFeaturesService
+17. **Fixed snake_case variables** ✓:
+    - Converted ~60 snake_case variables to camelCase across 5 service files
+    - Preserved array keys as snake_case for JSON/AJAX responses (JavaScript compatibility)
+    - Maintained database column names and external API formats
+    - Applied 27 additional automatic fixes after conversions
 
 ### 📊 Final Status (After All Fixes)
 - **Total Errors**: 2,142 (down from 3,671) - 42% reduction
-- **Total Warnings**: 752 (down from 1,196) - 37% reduction
-- **Total Issues**: 2,894 (down from 4,867) - 41% reduction
+- **Total Warnings**: 497 (down from 1,196) - 58% reduction
+- **Total Issues**: 2,639 (down from 4,867) - 46% reduction
 - **Files with Issues**: 43
-- **Automatic fixes applied**: 1,250 total (across all phases)
+- **Automatic fixes applied**: 1,277 total (across all phases)
 
 ## Top Priority Issues to Fix
 


### PR DESCRIPTION
- Documented conversion of ~60 snake_case variables to camelCase
- Warnings reduced from 752 to 497 (58% reduction)
- Total issues reduced by 46% (from 4,867 to 2,639)
- Applied total of 1,277 automatic fixes across all phases

🤖 Generated with [Claude Code](https://claude.ai/code) #109
