### PR TITLE
Fix REST API URLs for WordPress subdirectory installations

### DIFF
--- a/assets/js/quiz-ai-integration-copilot.js
+++ b/assets/js/quiz-ai-integration-copilot.js
@@ -190,7 +190,12 @@
          */
         loadAllLessons() {
             // Get lessons using REST API
-            $.get('/wp-json/wp/v2/mpcs-lesson?per_page=100', (lessons) => {
+            $.ajax({
+                url: mpcc_ajax.rest_url + 'mpcs-lesson?per_page=100',
+                headers: {
+                    'X-WP-Nonce': mpcc_ajax.rest_nonce
+                }
+            }).done((lessons) => {
                 const $select = $('#mpcc-lesson-select');
                 $select.empty().append('<option value="">Select a lesson...</option>');
                 

--- a/assets/js/quiz-ai-modal.js
+++ b/assets/js/quiz-ai-modal.js
@@ -321,8 +321,11 @@
                         // Verify the post is actually a lesson via REST API
                         // This prevents false positives from other post types
                         $.ajax({
-                            url: '/wp-json/wp/v2/mpcs-lesson/' + referrerMatch[1],
+                            url: mpcc_ajax.rest_url + 'mpcs-lesson/' + referrerMatch[1],
                             async: false,  // Synchronous to complete detection before modal opens
+                            headers: {
+                                'X-WP-Nonce': mpcc_ajax.rest_nonce
+                            },
                             success: (lesson) => {
                                 this.currentLessonId = parseInt(lesson.id, 10);
                                 this.detectionMethod = 'referrer';
@@ -1278,8 +1281,12 @@
         loadSingleLesson() {
             const $select = $('#mpcc-modal-lesson-select');
             
-            $.get(`/wp-json/wp/v2/mpcs-lesson/${this.currentLessonId}`)
-                .done((lesson) => {
+            $.ajax({
+                url: mpcc_ajax.rest_url + 'mpcs-lesson/' + this.currentLessonId,
+                headers: {
+                    'X-WP-Nonce': mpcc_ajax.rest_nonce
+                }
+            }).done((lesson) => {
                     const lessons = [{
                         id: lesson.id,
                         title: { rendered: lesson.title.rendered }
@@ -1317,8 +1324,12 @@
         loadRecentLessons() {
             const $select = $('#mpcc-modal-lesson-select');
             
-            $.get('/wp-json/wp/v2/mpcs-lesson?per_page=50&orderby=modified&order=desc')
-                .done((lessons) => {
+            $.ajax({
+                url: mpcc_ajax.rest_url + 'mpcs-lesson?per_page=50&orderby=modified&order=desc',
+                headers: {
+                    'X-WP-Nonce': mpcc_ajax.rest_nonce
+                }
+            }).done((lessons) => {
                     this.populateLessonDropdown($select, lessons);
                     
                     // Add note about limited results

--- a/src/MemberPressCoursesCopilot/Services/AssetManager.php
+++ b/src/MemberPressCoursesCopilot/Services/AssetManager.php
@@ -302,14 +302,18 @@ class AssetManager extends BaseService
 
         // Quiz AI Modal localizations
         wp_localize_script('mpcc-quiz-ai-modal', 'mpcc_ajax', [
-            'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce'    => NonceConstants::create(NonceConstants::QUIZ_AI),
+            'ajax_url'   => admin_url('admin-ajax.php'),
+            'rest_url'   => rest_url('wp/v2/'),
+            'rest_nonce' => wp_create_nonce('wp_rest'),
+            'nonce'      => NonceConstants::create(NonceConstants::QUIZ_AI),
         ]);
 
         // Quiz AI Simple localizations
         wp_localize_script('mpcc-quiz-ai-integration-simple', 'mpcc_ajax', [
-            'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce'    => NonceConstants::create(NonceConstants::QUIZ_AI),
+            'ajax_url'   => admin_url('admin-ajax.php'),
+            'rest_url'   => rest_url('wp/v2/'),
+            'rest_nonce' => wp_create_nonce('wp_rest'),
+            'nonce'      => NonceConstants::create(NonceConstants::QUIZ_AI),
         ]);
 
         // AI chat interface localizations
@@ -322,9 +326,11 @@ class AssetManager extends BaseService
 
         // Quiz AI localizations
         $quizAILocalization = [
-            'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce'    => NonceConstants::create(NonceConstants::QUIZ_AI),
-            'strings'  => [
+            'ajax_url'   => admin_url('admin-ajax.php'),
+            'rest_url'   => rest_url('wp/v2/'),
+            'rest_nonce' => wp_create_nonce('wp_rest'),
+            'nonce'      => NonceConstants::create(NonceConstants::QUIZ_AI),
+            'strings'    => [
                 'generate_button' => __('Generate', 'memberpress-courses-copilot'),
                 'generating'      => __('Generating questions...', 'memberpress-courses-copilot'),
                 'error'           => __('Error generating questions', 'memberpress-courses-copilot'),


### PR DESCRIPTION
The plugin was using hardcoded REST API URLs (/wp-json/wp/v2/) which fail when WordPress is installed in a subdirectory. This fix:

- Updates AssetManager to provide rest_url() and REST nonce to all scripts
- Replaces hardcoded /wp-json/ URLs with dynamic rest_url in JavaScript
- Adds proper REST authentication headers using X-WP-Nonce
- Updates quiz-ai-modal.js and quiz-ai-integration-copilot.js

This ensures the plugin works correctly regardless of WordPress installation configuration (root domain, subdirectory, or custom REST prefix).

Fixes #801 - XHR failed loading on subdirectory installations

🤖 Generated with [Claude Code](https://claude.ai/code)